### PR TITLE
Fix CIDR-expanded targets being silently dropped (#24)

### DIFF
--- a/Python/sharehound/targets.py
+++ b/Python/sharehound/targets.py
@@ -136,7 +136,7 @@ def load_targets(options: argparse.Namespace, config: Config, logger: Logger):
     # Parsing target to filter IP/DNS/CIDR
     for target in targets:
         if is_ipv4_cidr(target):
-            final_targets += [("ip", ip) for ip in expand_cidr(target)]
+            final_targets += [("ipv4", ip) for ip in expand_cidr(target)]
         elif is_ipv4_addr(target):
             final_targets.append(("ipv4", target))
         elif is_ipv6_addr(target):


### PR DESCRIPTION
### Linked Issue
Closes #24

### Root Cause
`load_targets()` in `Python/sharehound/targets.py` tagged each address produced from an IPv4 CIDR with the literal string `"ip"`, while the worker's dispatch in `Python/sharehound/worker.py` only recognises `"fqdn"`, `"ipv4"`, and `"ipv6"`. Any `"ip"`-typed tuple fell through to the `else` branch, was logged at debug level, counted as an error, and the target was never scanned. The bug was an inconsistent string literal between two modules that communicate via a structured tuple but share no enum definition.

### Fix Description
Tag CIDR-expanded IPv4 addresses as `"ipv4"` so they match the branch the worker already uses for single IPv4 targets. This is the minimal change: one string literal.

### How Verified
Static: after the change, `targets.py:139` emits `("ipv4", ip)` tuples for CIDR output. These satisfy `worker.py:367` (`elif target_type == "ipv4" or target_type == "ipv6"`), so `target_ip` is assigned and the scan proceeds identically to single IPv4 targets.

### Test Coverage
**None:** the fix is a one-character correction to a literal that would only be exercised by an end-to-end run with a live SMB target; no existing unit-test harness covers `load_targets()` in `Python/sharehound/tests/`.

### Scope of Change
- **Files changed:** `Python/sharehound/targets.py`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Trivial and local. The new type tag is already the one the worker accepts for single IPv4 addresses, so behaviour for CIDR targets now matches single-IPv4 behaviour. No migration or flag required.