### PR TITLE
Fix parse_rules duplicating every rule via self-extend (#26)

### DIFF
--- a/Python/sharehound/__main__.py
+++ b/Python/sharehound/__main__.py
@@ -71,8 +71,6 @@ def parse_rules(options: argparse.Namespace, logger: Logger) -> list[Rule]:
     elif len(options.rule_string) > 0:
         rules_text = "\n".join(options.rule_string)
         parsed_rules, parsing_errors = rp.parse(rules_text)
-        parsed_rules.extend(parsed_rules)
-        parsing_errors.extend(parsing_errors)
 
     if len(parsing_errors) > 0:
         logger.error("Errors while parsing rules:")


### PR DESCRIPTION
### Linked Issue
Closes #26

### Root Cause
After `parsed_rules, parsing_errors = rp.parse(rules_text)` in `parse_rules()`, the code invoked `parsed_rules.extend(parsed_rules)` and `parsing_errors.extend(parsing_errors)`. `list.extend(self)` walks the list in its current state and appends each element, doubling the list. The evaluator and debug logging then saw every rule twice for every rule-string invocation, including the default rule set (because `parseArgs` assigns `options.rule_string = DEFAULT_RULES` when no `-rs`/`-rf` is passed, which falls into the same branch).

### Fix Description
Remove the two self-extends. `rp.parse()` already returns the complete list of rules and the complete list of errors for the single rules string that is passed in, and no outer accumulator was intended — the variables bound on the assignment line are the final results.

### How Verified
Static: with the two `extend` calls removed, `parse_rules()` returns exactly the list produced by `rp.parse()`. The subsequent `for rule_no, rule in enumerate(parsed_rules, start=1)` debug loop now prints each rule once.

### Test Coverage
**None:** the removed lines have no unit-test coverage in `Python/sharehound/tests/`. Writing a targeted test would require stubbing `shareql.grammar.parser.RuleParser`, which is out of scope for a minimal fix.

### Scope of Change
- **Files changed:** `Python/sharehound/__main__.py`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Trivial and local. Downstream rule evaluation becomes correct (no more double evaluation per share/file/directory). No flag or migration needed.