### PR TITLE
Add disk-backed StreamingOpenGraph to bound Python memory (#28)

### DIFF
--- a/Python/sharehound/__main__.py
+++ b/Python/sharehound/__main__.py
@@ -13,7 +13,6 @@ from threading import Lock
 
 import argcomplete
 import ldap3.core.exceptions
-from bhopengraph.OpenGraph import OpenGraph
 from rich.console import Console
 from shareql.ast.rule import Rule
 from shareql.grammar.parser import RuleParser
@@ -22,6 +21,7 @@ import sharehound.kinds as kinds
 from sharehound.__version__ import __version__
 from sharehound.core.Config import Config
 from sharehound.core.Logger import Logger
+from sharehound.core.StreamingOpenGraph import StreamingOpenGraph
 from sharehound.status import status
 from sharehound.targets import load_targets
 from sharehound.utils.delta_time import delta_time
@@ -350,13 +350,14 @@ def main():
     logger.info("Starting ShareHound")
     timestamp_start = time.time()
 
-    graph = OpenGraph(source_kind=kinds.node_kind_network_share_base)
+    graph = StreamingOpenGraph(source_kind=kinds.node_kind_network_share_base)
 
     targets = []
     try:
         targets = load_targets(options, config, logger)
     except ldap3.core.exceptions.LDAPSocketOpenError as err:
         logger.error("Failed to connect to the LDAP server: %s" % str(err))
+        graph.close()
         sys.exit(1)
     except Exception as err:
         logger.error("Failed to load targets: %s" % str(err))
@@ -364,6 +365,7 @@ def main():
             import traceback
 
             traceback.print_exc()
+        graph.close()
         sys.exit(1)
     logger.info("Targeting %d hosts" % len(targets))
 
@@ -415,11 +417,14 @@ def main():
     logger.increment_indent()
     logger.info("Nodes: %d" % graph.get_node_count())
     logger.info("Edges: %d" % graph.get_edge_count())
-    graph.export_to_file(outfile, include_metadata=False)
-    logger.info(
-        'Graph successfully exported to "%s" (%s)'
-        % (outfile, filesize(os.path.getsize(outfile)))
-    )
+    try:
+        graph.export_to_file(outfile, include_metadata=False)
+        logger.info(
+            'Graph successfully exported to "%s" (%s)'
+            % (outfile, filesize(os.path.getsize(outfile)))
+        )
+    finally:
+        graph.close()
     logger.decrement_indent()
 
     # Display final summary

--- a/Python/sharehound/core/StreamingOpenGraph.py
+++ b/Python/sharehound/core/StreamingOpenGraph.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File name          : StreamingOpenGraph.py
+# Author             : Remi Gascou (@podalirius_)
+# Date created       : 19 Apr 2026
+
+import json
+import os
+import tempfile
+import threading
+from typing import Optional, Set
+
+from bhopengraph.Edge import Edge
+from bhopengraph.Node import Node
+from bhopengraph.OpenGraph import OpenGraph
+
+
+class StreamingOpenGraph(OpenGraph):
+    """
+    Disk-backed OpenGraph that keeps peak memory usage bounded regardless
+    of graph size.
+
+    Nodes and edges are serialized to NDJSON temporary files as they are
+    added. Only a set of node-ID and edge-key strings is kept in memory
+    for deduplication. Export streams from disk so the full graph is
+    never materialized as Python objects again.
+
+    This mirrors the approach taken by the Go implementation to handle
+    file servers large enough to exhaust host memory when the full graph
+    is held as in-memory Node/Edge objects.
+    """
+
+    def __init__(self, source_kind: Optional[str] = None):
+        super().__init__(source_kind=source_kind)
+
+        # Drop the parent's in-memory dicts; we won't use them.
+        self.nodes = {}
+        self.edges = {}
+
+        self._node_ids: Set[str] = set()
+        self._edge_keys: Set[str] = set()
+        self._edge_count = 0
+
+        self._lock = threading.Lock()
+
+        fd_nodes, self._node_path = tempfile.mkstemp(
+            prefix="sharehound-nodes-", suffix=".ndjson"
+        )
+        fd_edges, self._edge_path = tempfile.mkstemp(
+            prefix="sharehound-edges-", suffix=".ndjson"
+        )
+        os.close(fd_nodes)
+        os.close(fd_edges)
+
+        self._node_file = open(self._node_path, "w", buffering=256 * 1024)
+        self._edge_file = open(self._edge_path, "w", buffering=256 * 1024)
+        self._closed = False
+
+    # ---- add / count overrides -------------------------------------------------
+
+    def add_node(self, node: Node) -> bool:
+        if not isinstance(node, Node):
+            return False
+        with self._lock:
+            if node.id in self._node_ids:
+                return False
+
+            if self.source_kind and self.source_kind not in node.kinds:
+                node.add_kind(self.source_kind)
+
+            self._node_ids.add(node.id)
+            self._node_file.write(json.dumps(node.to_dict()))
+            self._node_file.write("\n")
+            return True
+
+    def add_node_without_validation(self, node: Node) -> bool:
+        return self.add_node(node)
+
+    def add_edge(self, edge: Edge) -> bool:
+        if not isinstance(edge, Edge):
+            return False
+        with self._lock:
+            if edge.start_node not in self._node_ids:
+                return False
+            if edge.end_node not in self._node_ids:
+                return False
+            return self._write_edge_locked(edge)
+
+    def add_edge_without_validation(self, edge: Edge) -> bool:
+        if not isinstance(edge, Edge):
+            return False
+        with self._lock:
+            return self._write_edge_locked(edge)
+
+    def _write_edge_locked(self, edge: Edge) -> bool:
+        edge_key = self._edge_key(edge)
+        if edge_key in self._edge_keys:
+            return False
+        self._edge_keys.add(edge_key)
+        self._edge_file.write(json.dumps(edge.to_dict()))
+        self._edge_file.write("\n")
+        self._edge_count += 1
+        return True
+
+    def get_node_count(self) -> int:
+        with self._lock:
+            return len(self._node_ids)
+
+    def get_edge_count(self) -> int:
+        with self._lock:
+            return self._edge_count
+
+    # ---- export ---------------------------------------------------------------
+
+    def export_json(self, include_metadata: bool = True, indent=None) -> str:
+        raise NotImplementedError(
+            "StreamingOpenGraph does not support export_json; use export_to_file."
+        )
+
+    def export_to_file(
+        self, filename: str, include_metadata: bool = True, indent=None
+    ) -> bool:
+        """
+        Stream the graph to `filename` as BloodHound OpenGraph JSON.
+
+        Reads nodes and edges one record at a time from the on-disk NDJSON
+        buffers so peak memory stays bounded.
+        """
+        with self._lock:
+            self._node_file.flush()
+            self._edge_file.flush()
+            node_path = self._node_path
+            edge_path = self._edge_path
+
+        try:
+            with open(filename, "w", buffering=64 * 1024) as out:
+                out.write("{\n")
+
+                if include_metadata and self.source_kind:
+                    out.write('  "metadata": {"source_kind": ')
+                    out.write(json.dumps(self.source_kind))
+                    out.write("},\n")
+
+                out.write('  "graph": {\n')
+
+                out.write('    "nodes": [')
+                self._stream_ndjson(out, node_path)
+                out.write("\n    ],\n")
+
+                out.write('    "edges": [')
+                self._stream_ndjson(out, edge_path)
+                out.write("\n    ]\n")
+
+                out.write("  }\n")
+                out.write("}\n")
+            return True
+        except (IOError, OSError, TypeError):
+            return False
+
+    @staticmethod
+    def _stream_ndjson(out, path: str) -> None:
+        first = True
+        with open(path, "r", buffering=256 * 1024) as src:
+            for line in src:
+                line = line.strip()
+                if not line:
+                    continue
+                if first:
+                    out.write("\n      ")
+                    first = False
+                else:
+                    out.write(",\n      ")
+                out.write(line)
+
+    # ---- disabled methods -----------------------------------------------------
+
+    def import_from_json(self, json_data: str) -> bool:
+        raise NotImplementedError("StreamingOpenGraph does not support import.")
+
+    def import_from_file(self, filename: str) -> bool:
+        raise NotImplementedError("StreamingOpenGraph does not support import.")
+
+    def import_from_dict(self, data) -> bool:
+        raise NotImplementedError("StreamingOpenGraph does not support import.")
+
+    def clear(self) -> None:
+        with self._lock:
+            self._node_ids.clear()
+            self._edge_keys.clear()
+            self._edge_count = 0
+            self._node_file.seek(0)
+            self._node_file.truncate()
+            self._edge_file.seek(0)
+            self._edge_file.truncate()
+
+    # ---- lifecycle ------------------------------------------------------------
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            for f, path in (
+                (self._node_file, self._node_path),
+                (self._edge_file, self._edge_path),
+            ):
+                try:
+                    f.close()
+                except Exception:
+                    pass
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
+            self._node_ids.clear()
+            self._edge_keys.clear()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/Python/sharehound/tests/test_streaming_opengraph.py
+++ b/Python/sharehound/tests/test_streaming_opengraph.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import json
+import os
+import tempfile
+import unittest
+
+from bhopengraph.Edge import Edge
+from bhopengraph.Node import Node
+from bhopengraph.Properties import Properties
+
+from sharehound.core.StreamingOpenGraph import StreamingOpenGraph
+
+
+class StreamingOpenGraphTests(unittest.TestCase):
+    def _make_node(self, id_: str, kind: str = "Thing") -> Node:
+        return Node(id=id_, kinds=[kind], properties=Properties(name=id_))
+
+    def _make_edge(self, start: str, end: str, kind: str = "Has") -> Edge:
+        return Edge(start_node=start, end_node=end, kind=kind)
+
+    def test_node_dedup_by_id(self):
+        g = StreamingOpenGraph()
+        try:
+            self.assertTrue(g.add_node_without_validation(self._make_node("a")))
+            self.assertFalse(
+                g.add_node_without_validation(self._make_node("a", "Different"))
+            )
+            self.assertEqual(g.get_node_count(), 1)
+        finally:
+            g.close()
+
+    def test_edge_dedup_by_key(self):
+        g = StreamingOpenGraph()
+        try:
+            g.add_node_without_validation(self._make_node("a"))
+            g.add_node_without_validation(self._make_node("b"))
+            self.assertTrue(
+                g.add_edge_without_validation(self._make_edge("a", "b", "Has"))
+            )
+            self.assertFalse(
+                g.add_edge_without_validation(self._make_edge("a", "b", "Has"))
+            )
+            self.assertTrue(
+                g.add_edge_without_validation(self._make_edge("a", "b", "Other"))
+            )
+            self.assertEqual(g.get_edge_count(), 2)
+        finally:
+            g.close()
+
+    def test_validated_add_edge_requires_nodes(self):
+        g = StreamingOpenGraph()
+        try:
+            self.assertFalse(g.add_edge(self._make_edge("a", "b")))
+            g.add_node_without_validation(self._make_node("a"))
+            self.assertFalse(g.add_edge(self._make_edge("a", "b")))
+            g.add_node_without_validation(self._make_node("b"))
+            self.assertTrue(g.add_edge(self._make_edge("a", "b")))
+        finally:
+            g.close()
+
+    def test_export_produces_valid_json(self):
+        g = StreamingOpenGraph(source_kind="TestKind")
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        )
+        tmp.close()
+        try:
+            g.add_node_without_validation(self._make_node("a"))
+            g.add_node_without_validation(self._make_node("b"))
+            g.add_edge_without_validation(self._make_edge("a", "b", "Has"))
+
+            self.assertTrue(g.export_to_file(tmp.name, include_metadata=True))
+
+            with open(tmp.name, "r") as f:
+                data = json.load(f)
+
+            self.assertEqual(data["metadata"]["source_kind"], "TestKind")
+            self.assertEqual(len(data["graph"]["nodes"]), 2)
+            self.assertEqual(len(data["graph"]["edges"]), 1)
+            self.assertEqual(data["graph"]["edges"][0]["kind"], "Has")
+        finally:
+            g.close()
+            os.unlink(tmp.name)
+
+    def test_export_empty_graph(self):
+        g = StreamingOpenGraph()
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        )
+        tmp.close()
+        try:
+            self.assertTrue(g.export_to_file(tmp.name, include_metadata=False))
+            with open(tmp.name, "r") as f:
+                data = json.load(f)
+            self.assertEqual(data["graph"]["nodes"], [])
+            self.assertEqual(data["graph"]["edges"], [])
+        finally:
+            g.close()
+            os.unlink(tmp.name)
+
+    def test_close_removes_temp_files(self):
+        g = StreamingOpenGraph()
+        node_path = g._node_path
+        edge_path = g._edge_path
+        self.assertTrue(os.path.exists(node_path))
+        self.assertTrue(os.path.exists(edge_path))
+        g.close()
+        self.assertFalse(os.path.exists(node_path))
+        self.assertFalse(os.path.exists(edge_path))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Linked Issue
Closes #28

### Motivation
Per #22 and #9, Python ShareHound's memory footprint grows linearly with the number of nodes and edges discovered, because `bhopengraph.OpenGraph` keeps every `Node` and `Edge` as a Python object in two in-memory dicts for the whole run. Large file servers exhaust host RAM, drive the box to swap, and can reboot before any output is written. The Go port already resolved this by streaming records to NDJSON temp files. This PR ports the same bound-memory approach to Python without altering output format.

### What Changed
- New class `Python/sharehound/core/StreamingOpenGraph.py` subclasses `bhopengraph.OpenGraph` and replaces its backing store:
  - Holds only `set[str]` of node IDs and `set[str]` of edge keys in memory for dedup.
  - Writes each node/edge to NDJSON temp files (`tempfile.mkstemp`, 256 KiB buffer) as soon as it is added, then drops the Python object.
  - `export_to_file()` streams the NDJSON buffers line-by-line into the final BloodHound JSON document; peak extra memory during export is one line.
  - `close()` (and `__exit__`/`__del__`) flushes, closes, and unlinks the temp files.
  - Import and `export_json` are explicitly `NotImplementedError` since the streaming model cannot rehydrate the full graph without loading it; the collector never calls those paths.
- `Python/sharehound/__main__.py` swaps `OpenGraph(...)` for `StreamingOpenGraph(...)` and calls `graph.close()` on success, target-loading errors, and LDAP errors so temp files are always cleaned up.
- `Python/sharehound/tests/test_streaming_opengraph.py` adds unit tests.

No changes in `OpenGraphContext` or the collectors — they use the same `add_node_without_validation` / `add_edge_without_validation` / counter API that `StreamingOpenGraph` exposes.

### Design Notes
- Dedup moves from storing full `Edge` objects keyed by `start|end|kind` to storing only the key string. The in-memory set is strictly smaller than the previous dict and preserves the original silently-deduplicating behavior for repeated edge writes across siblings sharing ancestor paths.
- I considered patching `bhopengraph` upstream; keeping the streaming variant inside ShareHound avoids coupling release cadences and keeps the blast radius contained.
- `add_edge` (validated) still checks that both endpoints are known nodes, matching `bhopengraph.OpenGraph.add_edge`. `add_edge_without_validation` bypasses that check as before.
- The JSON output shape matches `bhopengraph.OpenGraph.export_to_file`: top-level `metadata.source_kind` (when `include_metadata=True`) followed by `graph.nodes` and `graph.edges` arrays.

### Acceptance Criteria Check
- **Peak memory bounded by dedup sets:** `StreamingOpenGraph.add_node*` and `add_edge*` call `json.dumps(...).write(...)` then drop the Python object; only `_node_ids` and `_edge_keys` grow. Verified by inspection at `Python/sharehound/core/StreamingOpenGraph.py:68-100`.
- **Output format unchanged:** `test_export_produces_valid_json` parses the emitted file and checks `metadata.source_kind`, nodes count, edges count, and edge `kind`.
- **Dedup preserved:** `test_node_dedup_by_id`, `test_edge_dedup_by_key`.
- **Validated add_edge rejects unknown endpoints:** `test_validated_add_edge_requires_nodes`.
- **Temp files cleaned up:** `test_close_removes_temp_files`.
- **__main__ closes graph on all paths:** edits at `Python/sharehound/__main__.py` wrap `export_to_file` in try/finally and call `graph.close()` on LDAP/target-load failures.

### How Verified
Runtime: `PYTHONPATH=.:/tmp/bhopengraph-pkg python3 -m unittest sharehound.tests.test_streaming_opengraph -v` → 6 tests pass, 0 failures.

### Test Coverage
**Added:** `Python/sharehound/tests/test_streaming_opengraph.py`:
- `test_node_dedup_by_id`
- `test_edge_dedup_by_key`
- `test_validated_add_edge_requires_nodes`
- `test_export_produces_valid_json`
- `test_export_empty_graph`
- `test_close_removes_temp_files`

### Scope of Change
- **Files changed:** `Python/sharehound/__main__.py`, `Python/sharehound/core/StreamingOpenGraph.py` (new), `Python/sharehound/tests/test_streaming_opengraph.py` (new)
- **Submodule pointer updated:** no
- **Public API changes:** none (drop-in for the `graph` local in `main()`)
- **Behavioral changes outside the stated enhancement:** none

### Risk and Rollout
The collector path only calls `add_node_without_validation` / `add_edge_without_validation`, `get_node_count`, `get_edge_count`, and `export_to_file`; all are overridden with the same semantics. Temp files live under the system tempdir and are unlinked on close. The main behavioral risk is filesystem-backed writes under heavy concurrency — every mutator takes a `threading.Lock`, so writes are serialized (same guarantee as the dict-based parent class under the GIL plus the lock). Safe to ship without a flag or staged rollout; regressions would surface as a corrupted output file, which the new tests guard against.

### Notes
Follow-ups that become natural now that data is on-disk and not in Python objects:
- #10: partial output at regular intervals (NDJSON buffers can be snapshotted into a JSON file periodically).
- Optional zip output, matching `Go/internal/graph/opengraph.go`.

Neither is in scope for this PR.