### PR TITLE
Add visible progress bars and percentage columns (#11)

### DIFF
--- a/Python/sharehound/status.py
+++ b/Python/sharehound/status.py
@@ -7,7 +7,7 @@
 import time
 
 from rich.console import Console
-from rich.progress import Progress, TextColumn
+from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn
 from rich.text import Text
 
 
@@ -33,8 +33,8 @@ def status(console: Console, worker_results: dict, futures: list):
     # Create custom progress with our column
     custom_progress = Progress(
         TextColumn("{task.description}"),
-        # BarColumn(),
-        # TaskProgressColumn(),
+        BarColumn(),
+        TaskProgressColumn(),
         CustomProgressColumn(""),
         auto_refresh=True,
         refresh_per_second=1,


### PR DESCRIPTION
### Linked Issue
Closes #11

### Motivation
#11 asks for progress bars during collection. `Python/sharehound/status.py` already constructs a `rich.Progress` instance with custom processed/skipped/pending/total stats, but the visual bar and percentage columns were commented out, so the UI only showed the numeric counters without any bar. Users running long scans (#9) have no visual indication that work is progressing.

### What Changed
- Import `BarColumn` and `TaskProgressColumn` from `rich.progress` in `Python/sharehound/status.py`.
- Uncomment those two columns in the `Progress` constructor so each of the four tasks (hosts, shares, files, directories) renders a bar and a percentage alongside the existing `processed:... | skipped:... | pending:... | total:...` text.

No other changes to the status rendering, update loop, or worker counters — the existing update code already sets `completed` and `total` on every task at every tick, which is exactly what `BarColumn` and `TaskProgressColumn` need.

### Acceptance Criteria Check
- **Progress bars visible:** columns restored in the `Progress(...)` constructor at `Python/sharehound/status.py:34-41`.
- **Percentage column visible:** `TaskProgressColumn()` added alongside the bar.
- **Custom stats retained:** `CustomProgressColumn` still follows the bar/percentage, so processed/skipped/pending/total counters remain.
- **Four existing bars (hosts, shares, files, directories) all benefit:** columns are defined once on the `Progress` instance and apply to every added task.

### How Verified
Static: the update loop at `Python/sharehound/status.py:89-135` already calls `progress.update(task_id, completed=..., total=...)` for each of the four tasks at each tick, which is the exact data `BarColumn` and `TaskProgressColumn` render from. No additional state needs to be threaded to make the bars display.

### Test Coverage
**None:** the change is a UI tweak to `rich`-rendered output; there is no non-interactive test harness for `rich.Progress` rendering in this repo.

### Scope of Change
- **Files changed:** `Python/sharehound/status.py`
- **Submodule pointer updated:** no
- **Public API changes:** none
- **Behavioral changes outside the stated enhancement:** none

### Risk and Rollout
Trivial. The worst case is that on a terminal too narrow to show a bar, `rich` falls back gracefully. No flag needed.