### PR TITLE
Fix canPassTheHash always returning True (#32)

### DIFF
--- a/Python/sharehound/core/Credentials.py
+++ b/Python/sharehound/core/Credentials.py
@@ -117,19 +117,15 @@ class Credentials(object):
         """
         Determines if the current credentials can be used for a pass-the-hash attack.
 
-        This method checks if both LM and NT hashes are available and not None. If both hashes are set,
-        it indicates that the credentials may be used for a pass-the-hash attack.
+        This method checks if both LM and NT hashes are populated. If both hashes are
+        set to non-empty values, it indicates that the credentials may be used for a
+        pass-the-hash attack.
 
         Returns:
-            bool: True if both LM and NT hashes are available, False otherwise.
+            bool: True if both LM and NT hashes are populated, False otherwise.
         """
 
-        return bool(
-            (self.nt_hex is not None)
-            and (self.nt_raw is not None)
-            and (self.lm_hex is not None)
-            and (self.lm_raw is not None)
-        )
+        return bool(self.lm_hex and self.nt_hex and self.lm_raw and self.nt_raw)
 
     def __dict__(self):
         return {

--- a/Python/sharehound/tests/test_credentials.py
+++ b/Python/sharehound/tests/test_credentials.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from sharehound.core.Credentials import Credentials
+
+
+class CanPassTheHashTests(unittest.TestCase):
+    def test_no_hashes_false(self):
+        c = Credentials(domain="", username="", password="", hashes=None)
+        self.assertFalse(c.canPassTheHash())
+
+    def test_anonymous_false(self):
+        c = Credentials(domain="", username="user", password="pw")
+        self.assertFalse(c.canPassTheHash())
+
+    def test_hex_but_empty_raw_false(self):
+        c = Credentials(domain="", username="u", password="", hashes=None)
+        c.lm_hex = "aad3b435b51404eeaad3b435b51404ee"
+        c.nt_hex = "31d6cfe0d16ae931b73c59d7e0c089c0"
+        self.assertFalse(c.canPassTheHash())
+
+    def test_both_hashes_populated_true(self):
+        c = Credentials(domain="", username="u", password="", hashes=None)
+        c.lm_hex = "aad3b435b51404eeaad3b435b51404ee"
+        c.nt_hex = "31d6cfe0d16ae931b73c59d7e0c089c0"
+        c.lm_raw = b"\xaa\xd3\xb4\x35\xb5\x14\x04\xee\xaa\xd3\xb4\x35\xb5\x14\x04\xee"
+        c.nt_raw = b"\x31\xd6\xcf\xe0\xd1\x6a\xe9\x31\xb7\x3c\x59\xd7\xe0\xc0\x89\xc0"
+        self.assertTrue(c.canPassTheHash())
+
+    def test_only_nt_populated_false(self):
+        c = Credentials(domain="", username="u", password="", hashes=None)
+        c.nt_hex = "31d6cfe0d16ae931b73c59d7e0c089c0"
+        c.nt_raw = b"\x31\xd6\xcf\xe0\xd1\x6a\xe9\x31\xb7\x3c\x59\xd7\xe0\xc0\x89\xc0"
+        self.assertFalse(c.canPassTheHash())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Linked Issue
Closes #32

### Root Cause
`Credentials.set_hashes()` initialises `lm_hex`, `nt_hex`, `lm_raw`, `nt_raw` to empty values (`""`, `b""`) and only overwrites them when hash material is supplied. `canPassTheHash()` then checked each of those four attributes with `is not None`. Since empty string and empty bytes are not `None`, the conjunction was always True, making the method useless as a guard: it returned True even for anonymous credentials with no hash material. The defect is a mismatch between the "is populated" intent and the "is not None" check, made worse by the `set_hashes()` defaults being falsy-but-not-None.

### Fix Description
Replace the four `is not None` checks with a single truthiness conjunction: `bool(self.lm_hex and self.nt_hex and self.lm_raw and self.nt_raw)`. This returns True only when every hash field is a non-empty string/bytes. Behavior is now consistent with the docstring and with the `set_hashes()` defaults.

### How Verified
Runtime:
```
$ python3 -c "
from sharehound.core.Credentials import Credentials
print(Credentials(domain='', username='', password='', hashes=None).canPassTheHash())
print(Credentials(domain='', username='user', password='pw').canPassTheHash())
"
False
False
```

New unit tests exercise: no hashes, anonymous (no hashes), hex-but-empty-raw, only NT populated, and both populated.

### Test Coverage
**Added:** `Python/sharehound/tests/test_credentials.py`:
- `test_no_hashes_false`
- `test_anonymous_false`
- `test_hex_but_empty_raw_false`
- `test_only_nt_populated_false`
- `test_both_hashes_populated_true`

### Scope of Change
- **Files changed:** `Python/sharehound/core/Credentials.py`, `Python/sharehound/tests/test_credentials.py` (new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Trivial and local. `canPassTheHash` is defined on the `Credentials` class but is not called from anywhere inside ShareHound today, so the fix has no effect on the running collector. External callers and any future internal guard that would have made wrong decisions will now get the correct answer.

### Notes
While writing tests for this I discovered a separate bug in `utils.parse_lm_nt_hashes()`: when both LM and NT hashes are provided in the conventional `lm:nt` form, the parser falls through its three `elif` branches and returns `("", "")`. That silently breaks `--auth-hashes` in the common case. Will be filed and fixed as its own bug; out of scope here.