### PR TITLE
Fix parse_lm_nt_hashes dropping both hashes when both provided (#34)

### DIFF
--- a/Python/sharehound/tests/test_parse_lm_nt_hashes.py
+++ b/Python/sharehound/tests/test_parse_lm_nt_hashes.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from sharehound.utils.utils import parse_lm_nt_hashes
+
+LM_DEFAULT = "aad3b435b51404eeaad3b435b51404ee"
+NT_DEFAULT = "31d6cfe0d16ae931b73c59d7e0c089c0"
+LM_SAMPLE = "11111111111111111111111111111111"
+NT_SAMPLE = "22222222222222222222222222222222"
+
+
+class ParseLmNtHashesTests(unittest.TestCase):
+    def test_none_input(self):
+        self.assertEqual(parse_lm_nt_hashes(None), ("", ""))
+
+    def test_empty_string(self):
+        self.assertEqual(parse_lm_nt_hashes(""), ("", ""))
+
+    def test_both_hashes_preserved(self):
+        self.assertEqual(
+            parse_lm_nt_hashes(f"{LM_SAMPLE}:{NT_SAMPLE}"), (LM_SAMPLE, NT_SAMPLE)
+        )
+
+    def test_nt_only_substitutes_lm_default(self):
+        self.assertEqual(parse_lm_nt_hashes(f":{NT_SAMPLE}"), (LM_DEFAULT, NT_SAMPLE))
+
+    def test_lm_only_substitutes_nt_default(self):
+        self.assertEqual(parse_lm_nt_hashes(f"{LM_SAMPLE}:"), (LM_SAMPLE, NT_DEFAULT))
+
+    def test_both_hashes_case_normalized(self):
+        self.assertEqual(
+            parse_lm_nt_hashes(f"{LM_SAMPLE.upper()}:{NT_SAMPLE.upper()}"),
+            (LM_SAMPLE, NT_SAMPLE),
+        )
+
+    def test_whitespace_trimmed(self):
+        self.assertEqual(
+            parse_lm_nt_hashes(f"  {LM_SAMPLE}:{NT_SAMPLE}  "),
+            (LM_SAMPLE, NT_SAMPLE),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Python/sharehound/utils/utils.py
+++ b/Python/sharehound/utils/utils.py
@@ -55,6 +55,9 @@ def parse_lm_nt_hashes(lm_nt_hashes_string: str) -> tuple[str, str]:
         elif m_lm_hash is not None and m_nt_hash is None:
             lm_hash_value = m_lm_hash
             nt_hash_value = "31d6cfe0d16ae931b73c59d7e0c089c0"
+        else:
+            lm_hash_value = m_lm_hash
+            nt_hash_value = m_nt_hash
     return lm_hash_value, nt_hash_value
 
 


### PR DESCRIPTION
### Linked Issue
Closes #34

### Root Cause
`parse_lm_nt_hashes()` has three `elif` branches covering "all groups absent", "NT only" (substitute LM default), and "LM only" (substitute NT default). There was no branch for the conventional `lm:nt` case where both groups are captured. When both were present, the function fell past every branch and returned the initial `("", "")`, silently discarding the caller's hash string. The regex itself correctly captures both hashes; the conditional chain just had no home for that case.

The impact is end-to-end: `Credentials.set_hashes()` gets `("", "")`, stores empty strings, and `SMBSession._authenticate()` calls `smbClient.login(lmhash="", nthash="")`, so `--auth-hashes aad3...:31d6...` fails at login with no diagnostic that the hashes were dropped at parse time.

### Fix Description
Add an `else` branch that returns `(m_lm_hash, m_nt_hash)` unchanged when both groups are present. This is the minimal diff and keeps the default-substitution branches intact.

### How Verified
Runtime, before the fix:
```
>>> parse_lm_nt_hashes('aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0')
('', '')
```

After the fix:
```
>>> parse_lm_nt_hashes('aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0')
('aad3b435b51404eeaad3b435b51404ee', '31d6cfe0d16ae931b73c59d7e0c089c0')
```

### Test Coverage
**Added:** `Python/sharehound/tests/test_parse_lm_nt_hashes.py`:
- `test_none_input`, `test_empty_string`
- `test_both_hashes_preserved` (the regression the fix targets)
- `test_nt_only_substitutes_lm_default`
- `test_lm_only_substitutes_nt_default`
- `test_both_hashes_case_normalized` (upper-case input)
- `test_whitespace_trimmed`

All seven pass. Unit tests run: `python3 -m unittest sharehound.tests.test_parse_lm_nt_hashes -v`.

### Scope of Change
- **Files changed:** `Python/sharehound/utils/utils.py`, `Python/sharehound/tests/test_parse_lm_nt_hashes.py` (new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Trivial and local. The fix only adds a previously-missing branch; the three existing branches that handled partial input are unchanged, so default-substitution behaviour for `:nt` and `lm:` is identical. Safe to merge without a flag. Users currently working around this by relying on default-substitution quirks (e.g. passing `:nt`) are unaffected.