### PR TITLE
Fix ConnectionPool holding lock across network I/O (#36)

### DIFF
--- a/Python/sharehound/tests/test_connection_pool.py
+++ b/Python/sharehound/tests/test_connection_pool.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sharehound.worker import ConnectionPool
+
+
+class _FakeSession:
+    """Fake SMBSession that reports how long ping/close block the caller."""
+
+    def __init__(self, alive: bool = True, op_delay: float = 0.0):
+        self._alive = alive
+        self._op_delay = op_delay
+        self.ping_calls = 0
+        self.close_calls = 0
+
+    def ping_smb_session(self) -> bool:
+        self.ping_calls += 1
+        if self._op_delay:
+            time.sleep(self._op_delay)
+        return self._alive
+
+    def close_smb_session(self):
+        self.close_calls += 1
+        if self._op_delay:
+            time.sleep(self._op_delay)
+
+
+class ConnectionPoolLockScopeTests(unittest.TestCase):
+    def test_pooled_ping_runs_outside_lock(self):
+        pool = ConnectionPool(max_connections_per_host=2)
+        slow_session = _FakeSession(alive=True, op_delay=0.2)
+        pool._connections["host-a"].append(slow_session)
+
+        options = MagicMock()
+        other_thread_saw_lock_free = threading.Event()
+
+        def watcher():
+            # If the lock is held across the network I/O in ping, this
+            # acquire will block until the ping finishes.
+            deadline = time.monotonic() + 0.5
+            while time.monotonic() < deadline:
+                if pool._lock.acquire(blocking=False):
+                    try:
+                        other_thread_saw_lock_free.set()
+                        return
+                    finally:
+                        pool._lock.release()
+                time.sleep(0.01)
+
+        t = threading.Thread(target=watcher)
+        t.start()
+        # Let the watcher start before we enter get_connection.
+        time.sleep(0.02)
+        got = pool.get_connection("host-a", "host-a", options, MagicMock(), MagicMock())
+        t.join()
+
+        self.assertIs(got, slow_session)
+        self.assertEqual(slow_session.ping_calls, 1)
+        self.assertTrue(
+            other_thread_saw_lock_free.is_set(),
+            "ConnectionPool lock was held across ping_smb_session",
+        )
+
+    def test_return_connection_full_pool_closes_outside_lock(self):
+        pool = ConnectionPool(max_connections_per_host=1)
+        pool._connections["host-a"].append(_FakeSession())
+
+        slow_session = _FakeSession(op_delay=0.2)
+        other_thread_saw_lock_free = threading.Event()
+
+        def watcher():
+            deadline = time.monotonic() + 0.5
+            while time.monotonic() < deadline:
+                if pool._lock.acquire(blocking=False):
+                    try:
+                        other_thread_saw_lock_free.set()
+                        return
+                    finally:
+                        pool._lock.release()
+                time.sleep(0.01)
+
+        t = threading.Thread(target=watcher)
+        t.start()
+        time.sleep(0.02)
+        pool.return_connection("host-a", slow_session)
+        t.join()
+
+        self.assertEqual(slow_session.close_calls, 1)
+        self.assertTrue(
+            other_thread_saw_lock_free.is_set(),
+            "ConnectionPool lock was held across close_smb_session",
+        )
+
+    def test_close_all_closes_outside_lock(self):
+        pool = ConnectionPool(max_connections_per_host=2)
+        sessions = [_FakeSession(op_delay=0.1) for _ in range(3)]
+        pool._connections["host-a"].extend(sessions[:2])
+        pool._connections["host-b"].append(sessions[2])
+
+        other_thread_saw_lock_free = threading.Event()
+
+        def watcher():
+            deadline = time.monotonic() + 0.5
+            while time.monotonic() < deadline:
+                if pool._lock.acquire(blocking=False):
+                    try:
+                        other_thread_saw_lock_free.set()
+                        return
+                    finally:
+                        pool._lock.release()
+                time.sleep(0.01)
+
+        t = threading.Thread(target=watcher)
+        t.start()
+        time.sleep(0.02)
+        pool.close_all()
+        t.join()
+
+        for s in sessions:
+            self.assertEqual(s.close_calls, 1)
+        self.assertTrue(
+            other_thread_saw_lock_free.is_set(),
+            "ConnectionPool lock was held across close_all's close_smb_session calls",
+        )
+        self.assertEqual(pool._connections, {})
+
+    def test_new_connection_path_does_not_hold_lock_during_init(self):
+        pool = ConnectionPool(max_connections_per_host=2)
+        options = MagicMock()
+        # parse_lm_nt_hashes will see these values — they must be real strings.
+        options.auth_domain = ""
+        options.auth_user = "u"
+        options.auth_password = "p"
+        options.auth_hashes = None
+        options.use_kerberos = False
+        options.auth_key = None
+        options.kdc_host = None
+        options.advertised_name = None
+        logger = MagicMock()
+        other_thread_saw_lock_free = threading.Event()
+
+        def watcher():
+            deadline = time.monotonic() + 0.5
+            while time.monotonic() < deadline:
+                if pool._lock.acquire(blocking=False):
+                    try:
+                        other_thread_saw_lock_free.set()
+                        return
+                    finally:
+                        pool._lock.release()
+                time.sleep(0.01)
+
+        fake_session = MagicMock()
+
+        def slow_constructor(*_a, **_kw):
+            time.sleep(0.2)
+            return fake_session
+
+        with patch("sharehound.worker.SMBSession", side_effect=slow_constructor):
+            fake_session.init_smb_session.return_value = True
+            t = threading.Thread(target=watcher)
+            t.start()
+            time.sleep(0.02)
+            got = pool.get_connection("host-new", "host-new", options, MagicMock(), logger)
+            t.join()
+
+        self.assertIs(got, fake_session)
+        self.assertTrue(
+            other_thread_saw_lock_free.is_set(),
+            "ConnectionPool lock was held across new SMB session construction",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Python/sharehound/worker.py
+++ b/Python/sharehound/worker.py
@@ -51,67 +51,78 @@ class ConnectionPool:
         logger: Logger,
     ) -> Optional[SMBSession]:
         """Get an available connection for the host, creating one if needed."""
+        # Pop one pooled connection under the lock; do all network I/O outside.
+        pooled = None
         with self._lock:
-            # Try to reuse an existing connection
             if self._connections[host]:
-                connection = self._connections[host].pop()
-                if connection.ping_smb_session():
-                    return connection
-                else:
-                    # Connection is dead, close it
-                    try:
-                        connection.close_smb_session()
-                    except Exception:
-                        pass
-            # Create new connection
-            credentials = Credentials(
-                domain=options.auth_domain,
-                username=options.auth_user,
-                password=options.auth_password,
-                hashes=options.auth_hashes,
-                use_kerberos=options.use_kerberos,
-                aesKey=options.auth_key,
-                kdcHost=options.kdc_host,
-            )
+                pooled = self._connections[host].pop()
 
-            smb_session = SMBSession(
-                host=host,
-                port=445,
-                timeout=10,
-                credentials=credentials,
-                remote_name=remote_name,
-                advertisedName=options.advertised_name,
-                config=config,
-                logger=logger,
-            )
+        if pooled is not None:
+            if pooled.ping_smb_session():
+                return pooled
+            try:
+                pooled.close_smb_session()
+            except Exception:
+                pass
 
-            if smb_session.init_smb_session():
-                return smb_session
-            else:
-                return None
+        # Create a new connection outside the lock so other threads can
+        # continue to pop/push pooled connections while this SMB handshake
+        # is in progress.
+        credentials = Credentials(
+            domain=options.auth_domain,
+            username=options.auth_user,
+            password=options.auth_password,
+            hashes=options.auth_hashes,
+            use_kerberos=options.use_kerberos,
+            aesKey=options.auth_key,
+            kdcHost=options.kdc_host,
+        )
+
+        smb_session = SMBSession(
+            host=host,
+            port=445,
+            timeout=10,
+            credentials=credentials,
+            remote_name=remote_name,
+            advertisedName=options.advertised_name,
+            config=config,
+            logger=logger,
+        )
+
+        if smb_session.init_smb_session():
+            return smb_session
+        return None
 
     def return_connection(self, host: str, connection: SMBSession):
         """Return a connection to the pool for reuse."""
+        should_close = False
         with self._lock:
             if len(self._connections[host]) < self.max_connections_per_host:
                 self._connections[host].append(connection)
             else:
-                # Pool is full, close the connection
-                try:
-                    connection.close_smb_session()
-                except Exception:
-                    pass
+                should_close = True
+
+        if should_close:
+            try:
+                connection.close_smb_session()
+            except Exception:
+                pass
 
     def close_all(self):
         """Close all connections in the pool."""
         with self._lock:
-            for host_connections in self._connections.values():
-                for connection in host_connections:
-                    try:
-                        connection.close_smb_session()
-                    except Exception:
-                        pass
+            connections_to_close = [
+                connection
+                for host_connections in self._connections.values()
+                for connection in host_connections
+            ]
             self._connections.clear()
+
+        for connection in connections_to_close:
+            try:
+                connection.close_smb_session()
+            except Exception:
+                pass
 
 
 def retry_with_exponential_backoff(func, max_retries: int = 3, base_delay: float = 1.0):


### PR DESCRIPTION
### Linked Issue
Closes #36

### Root Cause
`ConnectionPool` used a single `threading.Lock` with `with self._lock:` blocks that encompassed everything the method did — including SMB session creation, `ping_smb_session()`, and `close_smb_session()`. The intent of the lock is to guard the in-memory `_connections` dict, but the scope was drawn around all of `get_connection`, `return_connection`, and `close_all`, which conflated "don't let two threads mutate `_connections[host]` at once" with "serialize everything the pool does." The practical effect is that any thread performing a new SMB dialect handshake or closing a stale connection blocks every other thread in the pool for the duration of that I/O, even threads working on unrelated hosts. Under load this reduces connection churn to a single-threaded critical path regardless of `--max-workers-per-host` and `--global-max-workers`.

### Fix Description
Narrow the lock scope to the minimum needed to mutate the shared dict:
- `get_connection`: pop a pooled connection under the lock, then do ping / fallback close / new-session construction / `init_smb_session` outside the lock.
- `return_connection`: decide under the lock whether the pool has room (append) or is full (record `should_close`), then perform `close_smb_session` outside the lock.
- `close_all`: collect all connections under the lock, clear the dict, release the lock, then close each connection outside the lock.

No changes to API surface, no changes to pool semantics (per-host capacity, LIFO reuse), and the ping-then-reuse fallback path is preserved.

### How Verified
Runtime: new tests in `Python/sharehound/tests/test_connection_pool.py` each start a watcher thread that repeatedly tries a non-blocking `acquire()` on the pool lock while the main thread is in a pool operation that performs a 100–200 ms simulated I/O. They assert the watcher observes the lock free during the I/O:
- `test_pooled_ping_runs_outside_lock`: lock is free during `ping_smb_session`.
- `test_return_connection_full_pool_closes_outside_lock`: lock is free during the fallback close.
- `test_close_all_closes_outside_lock`: lock is free during each of the three pooled closes.
- `test_new_connection_path_does_not_hold_lock_during_init`: patches `sharehound.worker.SMBSession` to a slow constructor and confirms the lock is free while it runs.

Ran `python3 -m unittest sharehound.tests.test_connection_pool -v` → 4 tests pass.

### Test Coverage
**Added:** `Python/sharehound/tests/test_connection_pool.py` with the four tests above.

### Scope of Change
- **Files changed:** `Python/sharehound/worker.py`, `Python/sharehound/tests/test_connection_pool.py` (new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. Semantics of the pool (per-host cap, reuse, new-session fallback, cleanup on close_all) are preserved; only the locking scope changed.

### Risk and Rollout
Moderate. The pool is touched by every worker thread, so a regression could manifest as connection-reuse or close-ordering issues. Mitigations in the patch: the critical section still single-writes to `_connections[host]`, `defaultdict(list)` remains the source of truth for per-host queues, and popping before I/O ensures a stale connection is never double-used by two threads. The tests exercise the three mutation sites and assert the lock is indeed released during I/O. Safe to merge without a flag.

### Notes
Related to #9 (week-long scans on a large file server) and #22 (memory pressure). Serialized connection churn is one of the pain points behind those reports; this change does not eliminate all serialization bottlenecks but removes the most invasive one.