### PR TITLE
Fix close_smb_session leaking dead connection resources (#38)

### DIFF
--- a/Python/sharehound/core/SMBSession.py
+++ b/Python/sharehound/core/SMBSession.py
@@ -196,22 +196,26 @@ class SMBSession(object):
         """
         Closes the current SMB session by disconnecting the SMB client.
 
-        This method ensures that the SMB client connection is properly closed. It checks if the client is connected
-        and if so, it closes the connection and resets the connection status.
+        Always calls ``self.smbClient.close()`` when an SMB client object
+        is attached, regardless of the cached ``self.connected`` flag, so
+        that connections marked dead by ``ping_smb_session()`` still
+        release their underlying socket and server-side state.
 
         Raises:
-            Exception: If the SMB client is not initialized or if there's an error during the disconnection process.
+            Exception: If the SMB client is not initialized.
         """
 
-        if self.smbClient is not None:
-            if self.connected:
-                self.smbClient.close()
-                self.connected = False
-                self.logger.debug("[+] SMB connection closed successfully.")
-            else:
-                self.logger.debug("[!] No active SMB connection to close.")
-        else:
+        if self.smbClient is None:
             raise Exception("SMB client is not initialized.")
+
+        try:
+            self.smbClient.close()
+        except Exception as err:
+            self.logger.debug(f"[!] Error while closing SMB client: {err}")
+        finally:
+            self.connected = False
+            self.smbClient = None
+            self.logger.debug("[+] SMB connection closed.")
 
     def init_smb_session(self) -> bool:
         """

--- a/Python/sharehound/tests/test_close_smb_session.py
+++ b/Python/sharehound/tests/test_close_smb_session.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sharehound.core.SMBSession import SMBSession
+
+
+def _make_session() -> SMBSession:
+    # Avoid calling __init__ which tries to list_shares() over the wire.
+    with patch.object(SMBSession, "list_shares", return_value={}):
+        return SMBSession(
+            host="10.0.0.1",
+            port=445,
+            timeout=1,
+            credentials=MagicMock(),
+            remote_name="10.0.0.1",
+            advertisedName=None,
+            config=MagicMock(),
+            logger=MagicMock(),
+        )
+
+
+class CloseSmbSessionTests(unittest.TestCase):
+    def test_close_when_connected(self):
+        s = _make_session()
+        s.smbClient = MagicMock()
+        s.connected = True
+        s.close_smb_session()
+        self.assertFalse(s.connected)
+        self.assertIsNone(s.smbClient)
+
+    def test_close_dead_connection_still_closes_client(self):
+        """ping_smb_session sets connected=False; close must still close."""
+        s = _make_session()
+        mock_client = MagicMock()
+        s.smbClient = mock_client
+        s.connected = False  # already marked dead by ping
+
+        s.close_smb_session()
+
+        mock_client.close.assert_called_once()
+        self.assertFalse(s.connected)
+        self.assertIsNone(s.smbClient)
+
+    def test_close_swallows_underlying_error(self):
+        s = _make_session()
+        mock_client = MagicMock()
+        mock_client.close.side_effect = RuntimeError("broken pipe")
+        s.smbClient = mock_client
+        s.connected = False
+
+        # Must not raise.
+        s.close_smb_session()
+
+        mock_client.close.assert_called_once()
+        self.assertFalse(s.connected)
+        self.assertIsNone(s.smbClient)
+
+    def test_close_without_smb_client_raises(self):
+        s = _make_session()
+        s.smbClient = None
+        with self.assertRaises(Exception):
+            s.close_smb_session()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Linked Issue
Closes #38

### Root Cause
`SMBSession.close_smb_session()` guarded the underlying `self.smbClient.close()` call on `if self.connected:`. The `self.connected` flag is flipped to False by `ping_smb_session()` when it detects a dead session (port closed or echo failure). Callers (notably `ConnectionPool.get_connection`) invoke `close_smb_session()` specifically to clean up a session that ping just reported dead — but at that point `self.connected` is already False, so the underlying impacket connection is never closed. The socket, tree ID, and any server-side session state persist until Python garbage-collects the `SMBConnection` object, which on a long-running scan with churn can accumulate significantly.

The defect is that `self.connected` was being used to mean two different things: "the session is usable" (set from ping) and "there is something to clean up" (used by close). Those concepts diverge the moment ping fails.

### Fix Description
Rework `close_smb_session()` to:
- Raise only when `self.smbClient is None` (nothing to clean up).
- Otherwise always call `self.smbClient.close()` inside a `try/except` so an already-broken connection still gets a close attempt without propagating errors.
- In a `finally` block, set `self.connected = False` and `self.smbClient = None` so the cleanup is durable and the session object cannot accidentally be reused afterwards.

This preserves the existing raise-on-uninitialised contract and adds no new exceptions to the code path.

### How Verified
Runtime: `python3 -m unittest sharehound.tests.test_close_smb_session -v` → 4 tests pass.

### Test Coverage
**Added:** `Python/sharehound/tests/test_close_smb_session.py`:
- `test_close_when_connected` — the healthy path still closes and clears state.
- `test_close_dead_connection_still_closes_client` — the regression: `connected=False` no longer skips close.
- `test_close_swallows_underlying_error` — a raising `close()` does not propagate, and the session is still marked closed.
- `test_close_without_smb_client_raises` — uninitialised client still raises (contract preserved).

### Scope of Change
- **Files changed:** `Python/sharehound/core/SMBSession.py`, `Python/sharehound/tests/test_close_smb_session.py` (new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** `self.smbClient = None` after close is new. It prevents accidental reuse of a closed client and keeps cleanup idempotent at a higher level. No caller in the tree reads `self.smbClient` after `close_smb_session()` returns; the only consumer of closed sessions is `ConnectionPool`, which discards them.

### Risk and Rollout
Local and well-tested. The previous behaviour silently leaked; the new behaviour actually closes. The additional `self.smbClient = None` is defensive; if any future code reuses a closed session it will now fail loudly (AttributeError) instead of silently using a broken connection. Safe to merge without a flag.

### Notes
Part of the same performance/stability bundle as #36 (connection pool lock scope). Both reduce the cost of dead-connection cleanup on long scans (#9).