### PR TITLE
Add FQDN and machine SID to share hosts

### DIFF
--- a/Python/sharehound/targets.py
+++ b/Python/sharehound/targets.py
@@ -12,11 +12,42 @@ from sectools.network.ip import (expand_cidr, is_ipv4_addr, is_ipv4_cidr,
                                  is_ipv6_addr)
 from sectools.windows.ldap.wrappers import (get_computers_from_domain,
                                             get_servers_from_domain,
-                                            get_subnets)
+                                            get_subnets, init_ldap_session,
+                                            parse_lm_nt_hashes)
 
 from sharehound.core.Config import Config
 from sharehound.core.Logger import Logger
 from sharehound.utils.utils import is_port_open
+
+
+def get_computer_sids_from_domain(options: argparse.Namespace):
+    lm_hash, nt_hash = parse_lm_nt_hashes(options.auth_hashes)
+    ldap_server, ldap_session = init_ldap_session(
+        auth_domain=options.auth_domain,
+        auth_dc_ip=options.auth_dc_ip,
+        auth_username=options.auth_user,
+        auth_password=options.auth_password,
+        auth_lm_hash=lm_hash,
+        auth_nt_hash=nt_hash,
+        auth_key=options.auth_key,
+        use_kerberos=options.use_kerberos,
+        kdcHost=options.kdc_host,
+        use_ldaps=options.ldaps,
+    )
+    searchbase = ldap_server.info.other["defaultNamingContext"]
+    sid_map = {}
+    for entry in ldap_session.extend.standard.paged_search(
+        searchbase, "(objectCategory=computer)", attributes=["dNSHostName", "objectSid"]
+    ):
+        if entry["type"] != "searchResEntry":
+            continue
+        dns_name = entry["attributes"]["dNSHostName"]
+        object_sid = entry["attributes"]["objectSid"]
+        if isinstance(dns_name, list):
+            dns_name = dns_name[0] if dns_name else None
+        if dns_name and object_sid:
+            sid_map[dns_name.lower()] = object_sid
+    return sid_map
 
 
 def load_targets(options: argparse.Namespace, config: Config, logger: Logger):
@@ -162,6 +193,14 @@ def load_targets(options: argparse.Namespace, config: Config, logger: Logger):
             "Skipped %d target(s) that did not parse as IPv4, IPv6, CIDR, or FQDN: %s"
             % (len(skipped_targets), ", ".join(repr(t) for t in skipped_targets))
         )
+
+    options.host_sid_map = {}
+    if (
+        options.auth_dc_ip is not None
+        and options.auth_user is not None
+        and (options.auth_password is not None or options.auth_hashes is not None)
+    ):
+        options.host_sid_map = get_computer_sids_from_domain(options)
 
     final_targets = sorted(list(set(final_targets)))
     return final_targets

--- a/Python/sharehound/worker.py
+++ b/Python/sharehound/worker.py
@@ -220,10 +220,16 @@ def process_share_task(
                 ogc = OpenGraphContext(graph=graph, logger=task_logger)
 
                 # Prepare host node
+                host_props = Properties(name=host)
+                if remote_name and remote_name != host:
+                    host_props.set_property("fqdn", remote_name)
+                    machine_sid = options.host_sid_map.get(remote_name.lower())
+                    if machine_sid:
+                        host_props.set_property("machineSid", machine_sid)
                 host_node = Node(
                     kinds=[kinds.node_kind_network_share_host],
                     id=host,
-                    properties=Properties(name=host),
+                    properties=host_props,
                 )
                 ogc.set_host(host_node)
 


### PR DESCRIPTION
Adds `machineSid` and `fqdn` to each `NetworkShareHost`, so a share host can be joined to its Computer node on `objectid`. The SID comes from the existing computer enumeration and the node id is unchanged.

Python collector only for now, happy to mirror in Go. IP and CIDR scans aren't enriched since there's no hostname to resolve. Tests added, and confirmed the output ingests into BloodHound CE.
