### PR TITLE
Add FQDN and machine SID to share hosts

### DIFF
--- a/Python/sharehound/targets.py
+++ b/Python/sharehound/targets.py
@@ -10,23 +10,54 @@ import os
 from sectools.network.domains import is_fqdn
 from sectools.network.ip import (expand_cidr, is_ipv4_addr, is_ipv4_cidr,
                                  is_ipv6_addr)
-from sectools.windows.ldap.wrappers import (get_computers_from_domain,
-                                            get_servers_from_domain,
-                                            get_subnets)
+from sectools.windows.ldap.wrappers import (get_servers_from_domain,
+                                            get_subnets, init_ldap_session,
+                                            parse_lm_nt_hashes)
 
 from sharehound.core.Config import Config
 from sharehound.core.Logger import Logger
 from sharehound.utils.utils import is_port_open
 
 
+def get_computers_with_sids_from_domain(options: argparse.Namespace):
+    lm_hash, nt_hash = parse_lm_nt_hashes(options.auth_hashes)
+    ldap_server, ldap_session = init_ldap_session(
+        auth_domain=options.auth_domain,
+        auth_dc_ip=options.auth_dc_ip,
+        auth_username=options.auth_user,
+        auth_password=options.auth_password,
+        auth_lm_hash=lm_hash,
+        auth_nt_hash=nt_hash,
+        auth_key=options.auth_key,
+        use_kerberos=options.use_kerberos,
+        kdcHost=options.kdc_host,
+        use_ldaps=options.ldaps,
+    )
+    searchbase = ldap_server.info.other["defaultNamingContext"]
+    computers = []
+    for entry in ldap_session.extend.standard.paged_search(
+        searchbase, "(objectCategory=computer)", attributes=["dNSHostName", "objectSid"]
+    ):
+        if entry["type"] != "searchResEntry":
+            continue
+        dns_name = entry["attributes"]["dNSHostName"]
+        object_sid = entry["attributes"]["objectSid"]
+        dns_names = dns_name if isinstance(dns_name, list) else [dns_name]
+        computers.extend((name, object_sid) for name in dns_names if name)
+    return computers
+
+
 def load_targets(options: argparse.Namespace, config: Config, logger: Logger):
     targets = []
-
-    if (
+    domain_computers = []
+    options.host_sid_map = {}
+    explicit_targets = options.targets_file is not None or len(options.target) != 0
+    has_ad_credentials = (
         options.auth_dc_ip is not None
         and options.auth_user is not None
         and (options.auth_password is not None or options.auth_hashes is not None)
-    ):
+    )
+    if has_ad_credentials:
         if not is_port_open(
             options.auth_dc_ip, (389 if not options.ldaps else 636), timeout=10
         ):
@@ -36,7 +67,7 @@ def load_targets(options: argparse.Namespace, config: Config, logger: Logger):
             )
             return []
 
-    if options.targets_file is not None or len(options.target) != 0:
+    if explicit_targets:
         # Loading targets line by line from a targets file
         if options.targets_file is not None:
             if os.path.exists(options.targets_file):
@@ -68,34 +99,17 @@ def load_targets(options: argparse.Namespace, config: Config, logger: Logger):
                 targets.append(target)
     else:
         # No explicit targets specified, load all computers from Active Directory
-        if (
-            options.auth_dc_ip is not None
-            and options.auth_user is not None
-            and (options.auth_password is not None or options.auth_hashes is not None)
-        ):
+        if has_ad_credentials:
             logger.info(
                 "No target list specified, fetching all computers from Active Directory domain '%s'"
                 % options.auth_domain
             )
 
-            # Loading targets from domain computers
-            logger.debug(
-                "[debug] Loading targets from computers in the domain '%s'"
-                % options.auth_domain
+            domain_computers = get_computers_with_sids_from_domain(options)
+            targets += [name for name, _ in domain_computers]
+            logger.info(
+                "Found %d computers in Active Directory" % len(domain_computers)
             )
-            computers = get_computers_from_domain(
-                auth_domain=options.auth_domain,
-                auth_dc_ip=options.auth_dc_ip,
-                auth_username=options.auth_user,
-                auth_password=options.auth_password,
-                auth_hashes=options.auth_hashes,
-                auth_key=options.auth_key,
-                use_kerberos=options.use_kerberos,
-                kdcHost=options.kdc_host,
-                use_ldaps=options.ldaps,
-            )
-            logger.info("Found %d computers in Active Directory" % len(computers))
-            targets += computers
 
             # Loading targets from domain servers
             logger.debug(
@@ -117,12 +131,7 @@ def load_targets(options: argparse.Namespace, config: Config, logger: Logger):
             targets += servers
 
         # Loading targets from subnetworks of the domain
-        if (
-            options.subnets
-            and options.auth_dc_ip is not None
-            and options.auth_user is not None
-            and (options.auth_password is not None or options.auth_hashes is not None)
-        ):
+        if options.subnets and has_ad_credentials:
             logger.debug(
                 "[debug] Loading targets from subnetworks of the domain '%s'"
                 % options.auth_domain
@@ -164,4 +173,13 @@ def load_targets(options: argparse.Namespace, config: Config, logger: Logger):
         )
 
     final_targets = sorted(list(set(final_targets)))
+
+    if explicit_targets and has_ad_credentials and any(
+        target_type == "fqdn" for target_type, _ in final_targets
+    ):
+        domain_computers = get_computers_with_sids_from_domain(options)
+
+    options.host_sid_map = {
+        name.lower(): sid for name, sid in domain_computers if sid
+    }
     return final_targets

--- a/Python/sharehound/tests/test_targets.py
+++ b/Python/sharehound/tests/test_targets.py
@@ -5,9 +5,10 @@ import argparse
 import os
 import tempfile
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-from sharehound.targets import load_targets
+from sharehound.targets import (get_computers_with_sids_from_domain,
+                                load_targets)
 
 
 def _base_options(**overrides):
@@ -78,6 +79,100 @@ class LoadTargetsMessagingTests(unittest.TestCase):
         self.assertIn(("ipv4", "10.0.0.1"), result)
         self.assertIn(("fqdn", "srv1.corp.example.com"), result)
         logger.warning.assert_not_called()
+
+
+class ComputerSidsTests(unittest.TestCase):
+    @patch("sharehound.targets.parse_lm_nt_hashes", return_value=("", ""))
+    @patch("sharehound.targets.init_ldap_session")
+    def test_parses_name_and_sid_pairs(self, mock_session, _hashes):
+        server = MagicMock()
+        server.info.other = {"defaultNamingContext": "DC=corp,DC=local"}
+        session = MagicMock()
+        session.extend.standard.paged_search.return_value = [
+            {"type": "searchResEntry", "attributes": {
+                "dNSHostName": "host1.corp.local", "objectSid": "S-1-5-21-1-2-3-1001"}},
+            {"type": "searchResEntry", "attributes": {
+                "dNSHostName": ["host2.corp.local", "host3.corp.local"],
+                "objectSid": "S-1-5-21-1-2-3-1002"}},
+            {"type": "searchResEntry", "attributes": {
+                "dNSHostName": "", "objectSid": "S-1-5-21-1-2-3-1003"}},
+            {"type": "searchResEntry", "attributes": {
+                "dNSHostName": "host4.corp.local", "objectSid": ""}},
+            {"type": "searchResRef", "attributes": {}},
+        ]
+        mock_session.return_value = (server, session)
+        opts = _base_options(
+            auth_dc_ip="10.0.0.1", auth_user="u", auth_password="p"
+        )
+        self.assertEqual(
+            get_computers_with_sids_from_domain(opts),
+            [
+                ("host1.corp.local", "S-1-5-21-1-2-3-1001"),
+                ("host2.corp.local", "S-1-5-21-1-2-3-1002"),
+                ("host3.corp.local", "S-1-5-21-1-2-3-1002"),
+                ("host4.corp.local", ""),
+            ],
+        )
+
+    @patch("sharehound.targets.get_servers_from_domain", return_value=[])
+    @patch("sharehound.targets.get_computers_with_sids_from_domain")
+    @patch("sharehound.targets.is_port_open", return_value=True)
+    def test_ad_scan_targets_all_computers_maps_only_sid_bearing(
+        self, _port, mock_comp, _srv
+    ):
+        mock_comp.return_value = [
+            ("host1.corp.local", "S-1-5-21-1-2-3-1001"),
+            ("host2.corp.local", ""),
+        ]
+        opts = _base_options(
+            auth_dc_ip="10.0.0.1", auth_user="u", auth_password="p"
+        )
+        result = load_targets(opts, MagicMock(), MagicMock())
+        self.assertEqual(
+            opts.host_sid_map, {"host1.corp.local": "S-1-5-21-1-2-3-1001"}
+        )
+        self.assertIn(("fqdn", "host1.corp.local"), result)
+        self.assertIn(("fqdn", "host2.corp.local"), result)
+
+    @patch("sharehound.targets.get_computers_with_sids_from_domain")
+    @patch("sharehound.targets.is_port_open", return_value=True)
+    def test_explicit_ip_and_cidr_do_not_query_ad(self, _port, mock_comp):
+        opts = _base_options(
+            auth_dc_ip="10.0.0.1",
+            auth_user="u",
+            auth_password="p",
+            target=["10.0.0.2", "10.0.0.3/32"],
+        )
+
+        result = load_targets(opts, MagicMock(), MagicMock())
+
+        self.assertEqual(
+            result,
+            [("ipv4", "10.0.0.2"), ("ipv4", "10.0.0.3")],
+        )
+        self.assertEqual(opts.host_sid_map, {})
+        mock_comp.assert_not_called()
+
+    @patch("sharehound.targets.get_computers_with_sids_from_domain")
+    @patch("sharehound.targets.is_port_open", return_value=True)
+    def test_explicit_fqdn_queries_ad_once(self, _port, mock_comp):
+        mock_comp.return_value = [
+            ("host1.corp.local", "S-1-5-21-1-2-3-1001")
+        ]
+        opts = _base_options(
+            auth_dc_ip="10.0.0.1",
+            auth_user="u",
+            auth_password="p",
+            target=["host1.corp.local"],
+        )
+
+        result = load_targets(opts, MagicMock(), MagicMock())
+
+        self.assertEqual(result, [("fqdn", "host1.corp.local")])
+        self.assertEqual(
+            opts.host_sid_map, {"host1.corp.local": "S-1-5-21-1-2-3-1001"}
+        )
+        mock_comp.assert_called_once_with(opts)
 
 
 if __name__ == "__main__":

--- a/Python/sharehound/tests/test_worker_host_properties.py
+++ b/Python/sharehound/tests/test_worker_host_properties.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from sharehound.worker import _build_host_properties
+
+
+class HostPropertiesTests(unittest.TestCase):
+    def setUp(self):
+        self.fqdn = "host1.corp.local"
+        self.sid = "S-1-5-21-1-2-3-1001"
+        self.sid_map = {self.fqdn: self.sid}
+
+    def test_unresolved_fqdn_is_enriched(self):
+        properties = _build_host_properties(
+            self.fqdn, self.fqdn, "fqdn", self.sid_map
+        ).get_all_properties()
+
+        self.assertEqual(
+            properties,
+            {"name": self.fqdn, "fqdn": self.fqdn, "machineSid": self.sid},
+        )
+
+    def test_resolved_fqdn_keeps_ip_identity_and_is_enriched(self):
+        properties = _build_host_properties(
+            "10.0.0.1", self.fqdn, "fqdn", self.sid_map
+        ).get_all_properties()
+
+        self.assertEqual(
+            properties,
+            {"name": "10.0.0.1", "fqdn": self.fqdn, "machineSid": self.sid},
+        )
+
+    def test_ip_target_is_not_enriched(self):
+        properties = _build_host_properties(
+            "10.0.0.1", "10.0.0.1", "ipv4", self.sid_map
+        ).get_all_properties()
+
+        self.assertEqual(properties, {"name": "10.0.0.1"})
+
+    def test_fqdn_without_sid_keeps_fqdn(self):
+        properties = _build_host_properties(
+            self.fqdn, self.fqdn, "fqdn", {}
+        ).get_all_properties()
+
+        self.assertEqual(properties, {"name": self.fqdn, "fqdn": self.fqdn})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Python/sharehound/worker.py
+++ b/Python/sharehound/worker.py
@@ -29,6 +29,18 @@ from sharehound.utils.delta_time import delta_time
 from sharehound.utils.utils import dns_resolve, is_port_open
 
 
+def _build_host_properties(
+    host: str, remote_name: str, target_type: str, host_sid_map: dict[str, str]
+) -> Properties:
+    properties = Properties(name=host)
+    if target_type == "fqdn":
+        properties.set_property("fqdn", remote_name)
+        machine_sid = host_sid_map.get(remote_name.lower())
+        if machine_sid:
+            properties.set_property("machineSid", machine_sid)
+    return properties
+
+
 class ConnectionPool:
     """
     Manages SMB session connections per host with connection reuse and concurrency limits.
@@ -154,6 +166,7 @@ def process_share_task(
     share_data: dict,
     host: str,
     remote_name: str,
+    target_type: str,
     options: argparse.Namespace,
     config: Config,
     graph: OpenGraph,
@@ -220,10 +233,13 @@ def process_share_task(
                 ogc = OpenGraphContext(graph=graph, logger=task_logger)
 
                 # Prepare host node
+                host_props = _build_host_properties(
+                    host, remote_name, target_type, options.host_sid_map
+                )
                 host_node = Node(
                     kinds=[kinds.node_kind_network_share_host],
                     id=host,
-                    properties=Properties(name=host),
+                    properties=host_props,
                 )
                 ogc.set_host(host_node)
 
@@ -451,6 +467,7 @@ def multithreaded_share_worker(
                     share_data,
                     target_ip,
                     remote_name,
+                    target_type,
                     options,
                     config,
                     graph,


### PR DESCRIPTION
Adds `machineSid` and `fqdn` to each `NetworkShareHost`, so a share host can be joined to its Computer node on `objectid`. The SID comes from the existing computer enumeration and the node id is unchanged.

Python collector only for now, happy to mirror in Go. IP and CIDR scans aren't enriched since there's no hostname to resolve. Tests added, and confirmed the output ingests into BloodHound CE.
